### PR TITLE
Add support for different history files

### DIFF
--- a/the_heck/src/main.rs
+++ b/the_heck/src/main.rs
@@ -5,7 +5,8 @@ mod shell_history;
 fn main() {
     // Get the last shell command
     let hist_path = shell_history::get_history_file_path();
-    let last_command = shell_history::read_last_line_history_file(hist_path);
+    println!("History file: {}", hist_path.to_str().unwrap());
+    let last_command = shell_history::get_last_command_from_shell_history(&hist_path);
     // Split the last command into words
     let split_last_command = last_command.split(' ').collect();
     // println!("Command line arguments: {:?}", split_last_command);

--- a/the_heck/src/main.rs
+++ b/the_heck/src/main.rs
@@ -5,7 +5,6 @@ mod shell_history;
 fn main() {
     // Get the last shell command
     let hist_path = shell_history::get_history_file_path();
-    println!("History file: {}", hist_path.to_str().unwrap());
     let last_command = shell_history::get_last_command_from_shell_history(&hist_path);
     // Split the last command into words
     let split_last_command = last_command.split(' ').collect();

--- a/the_heck/src/shell_history.rs
+++ b/the_heck/src/shell_history.rs
@@ -1,19 +1,72 @@
 use rev_buf_reader::RevBufReader;
+use std::env;
 use std::fs::File;
-use std::io::BufRead;
+use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
 
-pub fn get_history_file_path() -> PathBuf {
-    let user_home_dir = home::home_dir().expect("No home directory found.");
-    let root_dir = user_home_dir.as_path();
-    let mut hist_file_path = PathBuf::from(root_dir);
-    hist_file_path.push(".zsh_history");
+fn get_current_shell_config() -> PathBuf {
+    let shell_path = env::var("SHELL").expect("Cannot find current shell");
+    let mut user_home_dir = home::home_dir().expect("No home directory found.");
 
-    hist_file_path
+    // TODO: user might have changed their default shell config.
+    // How to handle that?
+    match shell_path.split("/").last().unwrap() {
+        "zsh" => user_home_dir.push(".zshrc"),
+        "bash" => user_home_dir.push(".bashrc"),
+        _ => panic!("Support for shell '{}' is not implemented yet.", shell_path),
+    };
+    user_home_dir
+}
+
+fn get_history_file_path_from_config(config_file_path: &PathBuf) -> Option<PathBuf> {
+    let zfile = File::open(config_file_path).expect("Could not open shell config file.");
+    let reader = BufReader::new(zfile);
+    let line_marker = "HISTFILE=";
+
+    let mut lines_iter = reader.lines().filter_map(Result::ok);
+
+    while let Some(line) = lines_iter.next() {
+        if line.starts_with(line_marker) {
+            let temp = PathBuf::from(line.split(line_marker).last().unwrap());
+            let mut hist_file_path = PathBuf::new();
+            if temp.starts_with("~") {
+                if let Some(home_dir) = home::home_dir() {
+                    hist_file_path.push(home_dir);
+                    hist_file_path.push(temp.strip_prefix("~").unwrap());
+                }
+            } else {
+                hist_file_path.push(temp);
+            }
+            return Some(hist_file_path);
+        }
+    }
+
+    None
+}
+
+pub fn get_history_file_path() -> PathBuf {
+    let shell_config_path = get_current_shell_config();
+
+    if let Some(hist_path_from_config) = get_history_file_path_from_config(&shell_config_path) {
+        // get history file from shell config if configured there
+        hist_path_from_config
+    } else {
+        // otherwise, use default history file for given shell
+        let mut hist_path_default = shell_config_path.parent().unwrap().to_owned().clone();
+        match shell_config_path.file_name().unwrap().to_str() {
+            Some(".zshrc") => hist_path_default.push(".zsh_history"),
+            Some(".bashrc") => hist_path_default.push(".bash_history"),
+            _ => panic!(
+                "Config file {} is not supported yet.",
+                shell_config_path.to_str().unwrap()
+            ),
+        }
+        hist_path_default
+    }
 }
 
 pub fn read_last_line_history_file(hist_file_path: PathBuf) -> String {
-    let file = File::open(hist_file_path).expect("Could not open file.");
+    let file = File::open(hist_file_path).expect("Could not open history file.");
     let buf = RevBufReader::new(file);
     // Takes the last 128 bytes of the file
     let last_lines_in_file: Vec<String> = buf

--- a/the_heck/src/shell_history.rs
+++ b/the_heck/src/shell_history.rs
@@ -72,7 +72,7 @@ pub fn get_last_command_from_shell_history(hist_file_path: &PathBuf) -> String {
         ".histfile" => get_last_command_from_histfile(&hist_file_path),
         _ => panic!("Support for {} is not implemented yet.", history_file_name),
     };
-    println!("Last command from shell: {}", last_command);
+    // println!("Last command from shell: {}", last_command);
     last_command
 }
 

--- a/the_heck/src/shell_history.rs
+++ b/the_heck/src/shell_history.rs
@@ -79,7 +79,11 @@ pub fn get_last_command_from_shell_history(hist_file_path: &PathBuf) -> String {
 fn get_last_command_from_histfile(histfile_path: &PathBuf) -> String {
     let file = File::open(histfile_path).expect("Could not open .histfile.");
     let reader = RevBufReader::new(file);
-    reader.lines().next().unwrap().unwrap()
+    reader
+        .lines()
+        .next()
+        .expect("Cannot find last line in .histfile")
+        .unwrap()
 }
 
 fn get_last_command_from_zsh_history(zsh_history_path: &PathBuf) -> String {

--- a/the_heck/src/shell_history.rs
+++ b/the_heck/src/shell_history.rs
@@ -13,10 +13,10 @@ fn get_current_shell_config() -> PathBuf {
     // TODO: user might have changed their default shell config.
     // Thus, if `heck` is run from a shell other than the default shell,
     // this approach won't work.
-    match shell_path.split("/").last().unwrap() {
+    match shell_path.split('/').last().unwrap() {
         "zsh" => user_home_dir.push(".zshrc"),
         "bash" => user_home_dir.push(".bashrc"),
-        _ => panic!("Support for shell '{}' is not implemented yet.", shell_path),
+        _ => panic!("Support for shell '{shell_path}' is not implemented yet."),
     };
     user_home_dir
 }
@@ -27,9 +27,9 @@ fn get_history_file_path_from_config(config_file_path: &PathBuf) -> Option<PathB
     let reader = BufReader::new(zfile);
     let line_marker = "HISTFILE=";
 
-    let mut lines_iter = reader.lines().filter_map(Result::ok);
+    let lines_iter = reader.lines().filter_map(Result::ok);
 
-    while let Some(line) = lines_iter.next() {
+    for line in lines_iter {
         if line.starts_with(line_marker) {
             let temp = PathBuf::from(line.split(line_marker).last().unwrap());
             let mut hist_file_path = PathBuf::new();
@@ -60,7 +60,7 @@ pub fn get_history_file_path() -> PathBuf {
         hist_path_from_config
     } else {
         // otherwise, use default history file for given shell
-        let mut hist_path_default = shell_config_path.parent().unwrap().to_owned().clone();
+        let mut hist_path_default = shell_config_path.parent().unwrap().to_owned();
         match shell_config_path.file_name().unwrap().to_str() {
             Some(".zshrc") => hist_path_default.push(".zsh_history"),
             Some(".bashrc") => hist_path_default.push(".bash_history"),
@@ -77,9 +77,9 @@ pub fn get_history_file_path() -> PathBuf {
 pub fn get_last_command_from_shell_history(hist_file_path: &PathBuf) -> String {
     let history_file_name = hist_file_path.file_name().unwrap().to_str().unwrap();
     let last_command = match history_file_name {
-        ".zsh_history" => get_last_command_from_zsh_history(&hist_file_path),
-        ".histfile" => get_last_command_from_histfile(&hist_file_path),
-        _ => panic!("Support for {} is not implemented yet.", history_file_name),
+        ".zsh_history" => get_last_command_from_zsh_history(hist_file_path),
+        ".histfile" => get_last_command_from_histfile(hist_file_path),
+        _ => panic!("Support for {history_file_name} is not implemented yet."),
     };
     // println!("Last command from shell: {}", last_command);
     last_command
@@ -111,7 +111,7 @@ fn get_last_command_from_zsh_history(zsh_history_path: &PathBuf) -> String {
         .split(';')
         .map(|borrow| borrow.to_owned())
         .collect();
-    let last_command = last_line[1].to_string();
+    
 
-    last_command
+    last_line[1].to_string()
 }


### PR DESCRIPTION
# What does this PR intend to do?

So far, `the_heck` only  supports the `zsh` shell. While I also use `zsh`, my prompt is [`starship`](https://github.com/starship/starship), which saves commands in `.histfile` instead of `.zsh_history`. Thus, in order to get `the_heck` working in my local environment I added support for command histories saved in `.histfile`.

In theory,  it should also work with `.bashrc`, but haven't tested it yet. Also, I think it should be relatively easy to extend the `shell_history.rs` module to add support for more shells and history files.

# Comments

@elizabeth-oda , I remember you said during your talk that you'd welcome PRs and collaboration.  Therefore, I played around a bit and came up with this first PR. I hope this is OK. Otherwise, feel free to ignore.

I'm also relatively new to Rust, so I'm sure a lot of things could  have been done much more elegantly (especially error handling; I use `panic!` a lot...